### PR TITLE
Not handled URL error message always displays GET as the http method used

### DIFF
--- a/fakeweb.js
+++ b/fakeweb.js
@@ -12,7 +12,13 @@ var fs = require('fs')
 
 
 
-function interceptable(uri) {
+function interceptable(uri, method) {
+    
+    if(typeof method === "undefined")
+    {
+        method = "GET";
+    }
+
     uri = parseUrl(uri);
     if (interceptedUris[uri]) {
         return true;
@@ -28,8 +34,8 @@ function interceptable(uri) {
             if (allowLocalConnect === true && requestIsLocal) {
                 return false;
             }
-            console.error("FAKEWEB: Unhandled GET request to " + uri);
-            throw "FAKEWEB: Unhandled GET request to " + uri;
+            console.error("FAKEWEB: Unhandled" + method + "request to " + uri);
+            throw "FAKEWEB: Unhandled " + method + " request to " + uri;
         } else {
             console.error("FAKEWEB: Invalid request");
             throw "FAKEWEB: Invalid request";
@@ -103,7 +109,7 @@ function Fakeweb() {
         }
 
         var url = options.uri || options.url;
-        if (interceptable(url)) {
+        if (interceptable(url, "POST")) {
             var resp = {statusCode : interceptedUris[url].statusCode};
             resp.headers = interceptedUris[url].headers;
             if (interceptedUris[url].contentType) {
@@ -123,7 +129,7 @@ function Fakeweb() {
         } else {
             uri = "https://" + options.host + options.path;
         }
-        if (interceptable(uri)) {
+        if (interceptable(uri, options.method)) {
             return httpModuleRequest(uri, callback);
         } else {
             return oldHttpsRequest.call(https, options, callback);
@@ -138,7 +144,7 @@ function Fakeweb() {
         } else {
             uri = "http://" + options.host + options.path;
         }
-        if (interceptable(uri)) {
+        if (interceptable(uri, options.method)) {
             return httpModuleRequest(uri, callback);
         } else {
             return oldHttpRequest.call(http, options, callback);

--- a/test/fakeweb-test.js
+++ b/test/fakeweb-test.js
@@ -55,16 +55,16 @@ vows.describe('Fakeweb').addBatch({
     },
     'will throw an exception with allowNetConnect off and you make ' : {
         'a GET request via request module' : function() {
-            assert.throws(function() { request.get({uri: 'http://www.test.com/'}); });
+            assert.throws(function() { request.get({uri: 'http://www.test.com/'}); }, /GET/);
         },
         'a POST request via request module' : function() {
-            assert.throws(function() { request.post({uri: 'http://www.test.com/'}); });
+            assert.throws(function() { request.post({uri: 'http://www.test.com/'}); }, /POST/);
         },
         'a request using the HTTP module' : function() {
-            assert.throws(function() { http.request({host: 'www.test.com', port: 80, path: '/', method: 'GET'}); });
+            assert.throws(function() { http.request({host: 'www.test.com', port: 80, path: '/', method: 'GET'}); }, /GET/);
         },
         'a request using the HTTPS module' : function() {
-            assert.throws(function() { https.request({host: 'www.test.com', port: 80, path: '/', method: 'GET'}); });
+            assert.throws(function() { https.request({host: 'www.test.com', port: 80, path: '/', method: 'GET'}); }, /GET/);
         }
     },
     'will not fail to intercept calls made using request directly' : {


### PR DESCRIPTION
Not handled URL error message always displays GET as the http method instead of the correct method:

When using request.post:

Expected:

```
FAKEWEB: Unhandled POST request to .....
```

Actual:

```
FAKEWEB: Unhandled GET request to .....
```

Added request method to the interceptable function to make sure the error shown displays the correct message. Modified tests to cover these scenarios.
