### PR TITLE
Make responses always a string instead of a buffer

### DIFF
--- a/fakeweb.js
+++ b/fakeweb.js
@@ -173,7 +173,7 @@ function Fakeweb() {
             if (options.binaryFile) {
                 interceptedUris[options.uri].response = fs.readFileSync(options.binaryFile, 'binary');
             } else {
-                interceptedUris[options.uri].response = fs.readFileSync(options.file);
+                interceptedUris[options.uri].response = fs.readFileSync(options.file).toString();
             }
         } else if (options.body != undefined) {
             interceptedUris[options.uri].response = options.body;

--- a/test/fakeweb-test.js
+++ b/test/fakeweb-test.js
@@ -21,7 +21,7 @@ vows.describe('Fakeweb').addBatch({
                 fakeweb.registerUri({uri: 'http://www.readme.com/', file: path.join(__dirname, 'fixtures', 'README.md')});
                 request.get({uri: 'http://www.readme.com/'}, this.callback); },
             "successfully" : function(err, resp, body) {
-                assert.equal(body.toString(), fixture);
+                assert.equal(body, fixture);
             }
         },
         "when queried with request passing a string as the uri": {
@@ -29,7 +29,7 @@ vows.describe('Fakeweb').addBatch({
                 fakeweb.registerUri({uri: 'http://www.readme.com/', file: path.join(__dirname, 'fixtures', 'README.md')});
                 request.get('http://www.readme.com/', this.callback); },
             "successfully" : function(err, resp, body) {
-                assert.equal(body.toString(), fixture);
+                assert.equal(body, fixture);
             }
         },
         "and when queried using ": {
@@ -72,7 +72,7 @@ vows.describe('Fakeweb').addBatch({
             fakeweb.registerUri({uri: 'http://www.readme.com/', file: path.join(__dirname, 'fixtures', 'README.md')});
             request('http://www.readme.com/', this.callback); },
         "successfully" : function(err, resp, body) {
-            assert.equal(body.toString(), fixture);
+            assert.equal(body, fixture);
         }
     },
     'will allow connections to local resources if allowLocalConnect ' : {


### PR DESCRIPTION
readFileSync returns a buffer but it should be a string instead since the body should always be a string. It worked on the test files because you were calling .toString() before comparing the values.
