### PR TITLE
Fix pipe undefined return value

### DIFF
--- a/fakeweb.js
+++ b/fakeweb.js
@@ -58,6 +58,7 @@ function httpModuleRequest(uri, callback) {
         thisResponse.pipe = function(outputStream) {
             outputStream.write(interceptedUris[uri].response);
             outputStream.end();
+            return outputStream;
         };
         thisResponse.statusCode = interceptedUris[uri].statusCode;
         thisResponse.headers = interceptedUris[uri].headers;


### PR DESCRIPTION
I think there's a small issue with fakeweb's implementation of response.pipe().

I have code that chains multiple pipe() calls in a response handler:
`res.pipe(someOtherTransformStream).pipe(anotherWritableStream);`

When not using fakeweb, this works.  
When I attempt to test with fakeweb, however this code throws an error ("can't call .pipe() on undefined").

The first pipe() (the one fakeweb overrides) returns undefined, causing the second call to pipe() to throw an error.  If I add the line `return outputStream;` to fakeweb's pipe implementation, everything works properly.

Groking your testing suite enough to add a test for this is proving a little tricky, so I hope you don't mind if I leave that bit up to you...
