### PR TITLE
returns a spy when you register to let you check that it was invoked.

### DIFF
--- a/fakeweb.js
+++ b/fakeweb.js
@@ -30,8 +30,6 @@ function interceptable(uri, method) {
         method = "GET";
     }
 
-    uri = parseUrl(uri);
-
     if (fakewebMatch(uri)) {
         return true;
     }
@@ -141,6 +139,7 @@ function Fakeweb() {
 
         var uri = options.uri || options.url;
         var followRedirect = options.followRedirect !== undefined ? options.followRedirect : true
+        uri = parseUrl(uri);
         if (interceptable(uri)) {
             var fakewebOptions = fakewebMatch(uri);
             updateSpy(uri, fakewebOptions);
@@ -169,6 +168,7 @@ function Fakeweb() {
         }
 
         var uri = options.uri || options.url;
+        uri = parseUrl(uri);
         if (interceptable(uri, "POST")) {
             var fakewebOptions = fakewebMatch(uri);
             updateSpy(uri, fakewebOptions);
@@ -194,6 +194,7 @@ function Fakeweb() {
         } else {
             uri = options;
         }
+        uri = parseUrl(uri);
         if (interceptable(uri, options.method)) {
             var fakewebOptions = fakewebMatch(uri);
             updateSpy(uri, fakewebOptions);
@@ -213,6 +214,7 @@ function Fakeweb() {
         } else {
             uri = options;
         }
+        uri = parseUrl(uri);
         if (interceptable(uri, options.method)) {
             var fakewebOptions = fakewebMatch(uri);
             updateSpy(uri, fakewebOptions);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "ctide <christide@christide.com> (http://www.github.com/ctide)",
   "name": "node-fakeweb",
   "description": "Fakeweb implementation in node for testing HTTP requests",
-  "version": "0.0.21",
+  "version": "0.2.0",
   "homepage": "http://www.github.com/ctide/fakeweb",
   "repository": {
     "type": "git",

--- a/test/fakeweb-test.js
+++ b/test/fakeweb-test.js
@@ -13,6 +13,7 @@ var vows = require('vows')
 console.error = function() {};
 fakeweb.allowNetConnect = false;
 fixture = fs.readFileSync(path.join(__dirname, 'fixtures', 'README.md')).toString();
+var spy, hookInvoked = null;
 
 vows.describe('Fakeweb').addBatch({
     "will read a fixture from disk and return that" : {
@@ -337,6 +338,29 @@ vows.describe('Fakeweb').addBatch({
                     assert.equal(resp.statusCode, 404);
                 });
             });
+        }
+    },
+    "will invoke spy-hook": {
+        topic: function() {
+            spy = fakeweb.registerUri({uri: 'http://www.readme.com/', body: ''});
+            hookInvoked = null;
+            spy.hook = function(uri) { hookInvoked = uri; };
+            request.post({uri: 'http://www.readme.com/'}, this.callback);
+        },
+        "successfully" : function(err, resp, body) {
+            assert.equal(resp.statusCode, 200);
+            assert.equal(hookInvoked, 'http://www.readme.com/');
+        }
+    },
+    "will return a spy for easy testing": {
+        topic: function() {
+            spy = fakeweb.registerUri({uri: 'http://www.readme.com/', body: ''});
+            request.post({uri: 'http://www.readme.com/'}, this.callback);
+        },
+        "successfully" : function(err, resp, body) {
+            assert.equal(resp.statusCode, 200);
+            assert(spy.used);
+            assert.equal(spy.useCount, 1);
         }
     }
 }).export(module);


### PR DESCRIPTION
This makes the registerUri function return a spy that can be checked in tests to verify that the expected requests were actually intercepted.

The spy also has a hook that you can attach a function to, so you will be able to do some logging for debugging purposes. This is especially nice when matching uris by Regex since you cant be sure exactly which uri was matched without this.
